### PR TITLE
Code cleanup, fix typos and reinforce Chinese copywriting rules

### DIFF
--- a/2023OctCourse.html
+++ b/2023OctCourse.html
@@ -1,190 +1,194 @@
-<!DOCTYPE html> 
- <head>
-     <meta charset="utf-8" /> 
-     <!--下面這行是標題-->
-     <title>SCAICT 10月主題課程</title> 
-     <meta name="viewport" content="width=device-width, initial-scale=1" /> 
-     <!--下面這行是縮圖，可以換網址-->
-     <link href="./src/img/favicon.ico" rel="icon" type="image/icon"> 
-     <link rel="stylesheet" type="text/css" href="https://Edit-Mr.github.io/css/Animate.css" media="screen"> 
-     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script> 
-    <!--下面這些是樣式，可以自由更換顏色之類的-->
-     <style> 
-         @import url(https://fonts.googleapis.com/earlyaccess/cwtexyen.css); 
-        *{
+<!DOCTYPE html>
+
+<head>
+    <meta charset="utf-8" />
+    <!-- 下面這行是標題 -->
+    <title>SCAICT 10 月主題課程</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- 下面這行是縮圖，可以換網址 -->
+    <link href="./src/img/favicon.ico" rel="icon" type="image/icon">
+    <link rel="stylesheet" type="text/css" href="https://Edit-Mr.github.io/css/Animate.css" media="screen">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <!-- 下面這些是樣式，可以自由更換顏色之類的 -->
+    <style>
+        @import url(https://fonts.googleapis.com/earlyaccess/cwtexyen.css);
+
+        * {
             box-sizing: border-box;
         }
-         body { 
-             font-family: "Arial","cwTeXYen","微軟正黑體"; 
-             background-color: #f1dc91; 
-         } 
-  
-         .container { 
-             max-width: 50vw; 
-             margin-left: auto; 
-             margin-right: auto; 
-             padding-left: 10px; 
-             padding-right: 10px; 
-             font-size: 25px; 
-         } 
-  
-         h2 { 
-             font-size: 1em; 
-             margin: 0; 
-             text-align: center; 
-             font-weight: 150; 
-             color: #0a02ea; 
-             animation: fadeIn; 
-             animation-duration: 1.5s; 
-             animate-delay: 0.9s; 
-         } 
-  
-         h1 { 
-             font-size: 3em; 
-             margin: 20px 0 0 0; 
-             text-align: center; 
-             size: 30px; 
-             color: #000000; 
-             animation: zoomIn; 
-             animation-duration: 1s; 
-         } 
-  
-         li { 
-             border-radius: 3px; 
-             padding: 25px 30px; 
-             display: flex; 
-             justify-content: space-between; 
-             margin-bottom: 25px; 
-         } 
-  
-         .responsive-table .table-header, 
-         .table-note { 
-             background-color: #f9a556; 
-             font-size: 30px; 
-             margin-top: 0px; 
-             padding: 25px 30px 25px 30px; 
-             animation: slideInUp; 
-             animation-duration: 1.5s; 
-         } 
-  
-         .table-note { 
-             font-size: 20px; 
-             display: none; 
-         } 
-  
-         .responsive-table { 
-             margin: 0; 
-             padding: 0; 
-         } 
-  
-         .responsive-table .table-row { 
-             background-color: #fbe7cd; 
-             box-shadow: 0px 0px 9px 0px rgba(0, 0, 0, 0.1); 
-             animation: backInLeft; 
-             animation-duration: 1.5s; 
-         } 
-         .responsive-table .col-1 { 
-             flex-basis: 25%; 
-         } 
-  
-         .responsive-table .col-2 { 
-             flex-basis: 30%; 
-         } 
-  
-         .responsive-table .col-3 { 
-             flex-basis: 30%; 
-         } 
-  
-         .responsive-table .col-4 { 
-             flex-basis: 15%; 
-         } 
-  
-         @media all and (max-width: 767px) { 
-             .responsive-table .table-header { 
-                 display: none; 
-             } 
-  
-             .table-note { 
-                 display: block; 
-             } 
-  
-             .responsive-table li { 
-                 display: block; 
-             } 
-  
-             .responsive-table .col { 
-                 flex-basis: 100%; 
-             } 
-  
-             .responsive-table .col { 
-                 display: flex; 
-                 padding: 10px 0; 
-             } 
-  
-             .responsive-table .col:before { 
-                 color: #6c7a89; 
-                 padding-right: 10px; 
-                 content: attr(data-label); 
-                 flex-basis: 50%; 
-                 text-align: right; 
-             } 
-         } 
-  
-         .header { 
-             width: 300px; 
-             display: block; 
-             margin: auto; 
-             animation: slideInUp; 
-             animation-duration: 1.5s; 
-         } 
-  
-         .finished { 
-             color: green; 
-         } 
-  
-         p, 
-         a { 
-             text-align: center; 
-             font-size: 15px; 
-             color: #6c7a89; 
-             text-decoration: none; 
-             animation: fadeIn; 
-             animation-duration: 1.5s; 
-         } 
-     </style> 
- </head> 
- <script> 
-    //GAS網址
-    let requestURL = "https://script.google.com/macros/s/AKfycbwMD6hHZK7SR0y9-EygDp4hU1WMfAJzrzhYLcZ40DHNlAfzLKz9y_u8VdT8ukGPMBHtKw/exec"; 
-    let request = new XMLHttpRequest(); 
-    request.open("GET", requestURL); 
-    request.responseType = "text"; 
-    request.send(); 
-    request.onload = function () { 
-        console.log("載入成功");
-        $("p").addClass('animate_animated','animate_fadeOut') //動畫
-        $(".responsive-table").html(request.response); //用表格取代.responsive-table
+
+        body {
+            font-family: "Arial", "cwTeXYen", "微軟正黑體";
+            background-color: #f1dc91;
+        }
+
+        .container {
+            max-width: 50vw;
+            margin-left: auto;
+            margin-right: auto;
+            padding-left: 10px;
+            padding-right: 10px;
+            font-size: 25px;
+        }
+
+        h2 {
+            font-size: 1em;
+            margin: 0;
+            text-align: center;
+            font-weight: 150;
+            color: #0a02ea;
+            animation: fadeIn;
+            animation-duration: 1.5s;
+        }
+
+        h1 {
+            font-size: 3em;
+            margin: 20px 0 0 0;
+            text-align: center;
+            size: 30px;
+            color: #000000;
+            animation: zoomIn;
+            animation-duration: 1s;
+        }
+
+        li {
+            border-radius: 3px;
+            padding: 25px 30px;
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 25px;
+        }
+
+        .responsive-table .table-header,
+        .table-note {
+            background-color: #f9a556;
+            font-size: 30px;
+            margin-top: 0px;
+            padding: 25px 30px 25px 30px;
+            animation: slideInUp;
+            animation-duration: 1.5s;
+        }
+
+        .table-note {
+            font-size: 20px;
+            display: none;
+        }
+
+        .responsive-table {
+            margin: 0;
+            padding: 0;
+        }
+
+        .responsive-table .table-row {
+            background-color: #fbe7cd;
+            box-shadow: 0px 0px 9px 0px rgba(0, 0, 0, 0.1);
+            animation: backInLeft;
+            animation-duration: 1.5s;
+        }
+
+        .responsive-table .col-1 {
+            flex-basis: 25%;
+        }
+
+        .responsive-table .col-2 {
+            flex-basis: 30%;
+        }
+
+        .responsive-table .col-3 {
+            flex-basis: 30%;
+        }
+
+        .responsive-table .col-4 {
+            flex-basis: 15%;
+        }
+
+        @media all and (max-width: 767px) {
+            .responsive-table .table-header {
+                display: none;
+            }
+
+            .table-note {
+                display: block;
+            }
+
+            .responsive-table li {
+                display: block;
+            }
+
+            .responsive-table .col {
+                flex-basis: 100%;
+            }
+
+            .responsive-table .col {
+                display: flex;
+                padding: 10px 0;
+            }
+
+            .responsive-table .col:before {
+                color: #6c7a89;
+                padding-right: 10px;
+                content: attr(data-label);
+                flex-basis: 50%;
+                text-align: right;
+            }
+        }
+
+        .header {
+            width: 300px;
+            display: block;
+            margin: auto;
+            animation: slideInUp;
+            animation-duration: 1.5s;
+        }
+
+        .finished {
+            color: green;
+        }
+
+        p,
+        a {
+            text-align: center;
+            font-size: 15px;
+            color: #6c7a89;
+            text-decoration: none;
+            animation: fadeIn;
+            animation-duration: 1.5s;
+        }
+    </style>
+</head>
+<script>
+    // GAS網址
+    let requestURL = 'https://script.google.com/macros/s/AKfycbwMD6hHZK7SR0y9-EygDp4hU1WMfAJzrzhYLcZ40DHNlAfzLKz9y_u8VdT8ukGPMBHtKw/exec';
+    let request = new XMLHttpRequest();
+    request.open('GET', requestURL);
+    request.responseType = 'text';
+    request.send();
+    request.onload = function () {
+        console.log('載入成功');
+        $('p').addClass('animate_animated', 'animate_fadeOut') // 動畫
+        $('.responsive-table').html(request.response); // 用表格取代 `.responsive-table`
     }; 
-</script> 
- <body> 
-     <div class="container"> 
-         <h1>SCAICT 10月主題課程</h1> 
-         <h2>網頁設計</h2> 
-         <img src="./src/img/logo_gradient_RedPink-removebg-preview_RGB.png" class="header" /> 
-         <li class="table-note"> 
-             如果要一次看完整表格請切換到電腦版網頁喔 
-         </li> 
-         <ul class="responsive-table"> 
-             <li class="table-header"> 
-                 <div class="col col-1">學員姓名</div> 
-                 <div class="col col-2">學校</div> 
-                 <div class="col col-3">完成時間</div> 
-                 <div class="col col-4">狀態</div> 
-             </li> 
-             資料載入中 
-         </ul> 
-         <p><a href="https://www.facebook.com/scaict.tw" target="_blank">Facebook</a> <br>
-            <a href="https://www.instagram.com/scaict.tw/"target="_blank">Instagram</a><br>
-            <a href="https://discord.com/invite/neQ7QEUcqe"target="_blank">Discord</a>
-     </div> 
- </body>
+</script>
+
+<body>
+    <div class="container">
+        <h1>SCAICT 10 月主題課程</h1>
+        <h2>網頁設計</h2>
+        <img src="./src/img/logo_gradient_RedPink-removebg-preview_RGB.png" class="header" />
+        <li class="table-note">
+            如果要一次看完整表格請切換到電腦版網頁。
+        </li>
+        <ul class="responsive-table">
+            <li class="table-header">
+                <div class="col col-1">學員姓名</div>
+                <div class="col col-2">學校</div>
+                <div class="col col-3">完成時間</div>
+                <div class="col col-4">狀態</div>
+            </li>
+            資料載入中……
+        </ul>
+        <p><a href="https://www.facebook.com/scaict.tw" target="_blank">Facebook</a> <br>
+            <a href="https://www.instagram.com/scaict.tw/" target="_blank">Instagram</a><br>
+            <a href="https://discord.com/invite/neQ7QEUcqe" target="_blank">Discord</a>
+    </div>
+</body>

--- a/3D.html
+++ b/3D.html
@@ -2,74 +2,74 @@
 <html lang="zh-tw">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>JavaScript & CSS 陀螺儀使圖片三維翻轉</title>
-    <script>
-        
-function permission() {
-    if (typeof (DeviceMotionEvent) !== "undefined" && typeof (DeviceMotionEvent.requestPermission) === "function") {
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JavaScript & CSS 陀螺儀使圖片三維翻轉</title>
+  <script>
+
+    function permission() {
+      if (typeof (DeviceMotionEvent) !== 'undefined' && typeof (DeviceMotionEvent.requestPermission) === 'function') {
         DeviceMotionEvent.requestPermission()
-            .then(response => {
-                var xyz_img = document.getElementById('xyz-img');
+          .then(response => {
+            let xyz_img = document.getElementById('xyz-img');
             if (window.DeviceOrientationEvent) {
-                window.addEventListener('deviceorientation', function (event) {
+              window.addEventListener('deviceorientation', function (event) {
 
-                        beta = Math.round(event.beta);
-                        gamma = Math.round(event.gamma);
-                        alpha = Math.round(event.alpha);
+                beta = Math.round(event.beta);
+                gamma = Math.round(event.gamma);
+                alpha = Math.round(event.alpha);
 
-                        xyz_img.style.transform = 'rotateX(' + beta + 'deg) rotateY(' + gamma +
-                            'deg) rotateZ(' + alpha + 'deg)';
-                        console.log("X:" + beta + " Y:" + gamma + " Z:" + alpha);
+                xyz_img.style.transform = 'rotateX(' + beta + 'deg) rotateY(' + gamma +
+                  'deg) rotateZ(' + alpha + 'deg)';
+                console.log('X:' + beta + ' Y:' + gamma + ' Z:' + alpha);
 
-                    },
-                    false);
+              },
+                false);
             } else {
-                document.querySelector('body').innerHTML = '瀏覽器不支援';
+              document.querySelector('body').innerHTML = '瀏覽器不支援';
             }
-            })
-            .catch(console.error)
-    } else {
-        alert("DeviceMotionEvent is not defined");
+          })
+          .catch(console.error)
+      } else {
+        alert('DeviceMotionEvent is not defined');
+      }
     }
-}
-const btn = document.getElementById( "request" );
-btn.addEventListener( "click", permission );
-    </script>
-    <style>
-        html,
-        body {
-            width: 100%;
-            height: 100%;
-            margin: 0;
-            padding: 0;
-        }
+    const btn = document.getElementById('request');
+    btn.addEventListener('click', permission);
+  </script>
+  <style>
+    html,
+    body {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
 
-        #container {
-            width: 100%;
-            height: 100%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
+    #container {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
 
-        #xyz-img {
-            margin: 0;
-            padding: 0;
-            width: 60%;
-            height: 60%;
-            background-image: url(https://mnya.tw/about/img/website.jpg);
-            background-size: auto;
-        }
-    </style>
+    #xyz-img {
+      margin: 0;
+      padding: 0;
+      width: 60%;
+      height: 60%;
+      background-image: url(https://mnya.tw/about/img/website.jpg);
+      background-size: auto;
+    }
+  </style>
 </head>
 
 <body>
-    <button id="request">aaa</button>
-    <div id="container">
-        <div id="xyz-img"></div>
-    </div>
+  <button id="request">aaa</button>
+  <div id="container">
+    <div id="xyz-img"></div>
+  </div>
 
 </body>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<div align=center>
-    
-# 中電會官方網站前端代碼
+# 中電會官方網站前端 Repository
 
 **編輯前請詳讀 [Wiki](https://github.com/SCAICT/website/wiki)**
 

--- a/flag/index.html
+++ b/flag/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>線上報到</title>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100;300;400;500;700;900&display=swap');
+
         :root {
             --background-rgb: 29 30 34;
             --blue-rgb: 33 150 243;
@@ -19,7 +21,7 @@
 
         body {
             background-color: rgb(var(--background-rgb));
-            font-family: '微軟正黑體', sans-serif;
+            font-family: 'Noto Sans TC', '微軟正黑體', sans-serif;
             color: #FFF;
             position: relative;
             height: 100vh;
@@ -42,7 +44,7 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            height: min(calc(100vh - 4rem),533.333333333333px);
+            height: min(calc(100vh - 4rem), 533.333333333333px);
             gap: 1rem;
             width: min(300px, 90vw);
             transition: all 1s ease;
@@ -159,46 +161,45 @@
         <h1>Save Data in Cookie</h1>
         <input type="text" id="dataInput" placeholder="傳說中的隊伍">
         <button onclick="saveDataInCookie()" id="submit">回報</button>
-        <p>Cookie 會記錄你的隊名<br>讓你下次可以直接送出</p>
+        <p>Cookie 會記錄你的隊名<br>讓你下次可以直接送出！</p>
     </main>
     <div class="success">
-        <h2>回報成功!</h2>
+        <h2>回報成功！</h2>
         <h3>繼續加油</h3>
-        <button onclick="window.close();">再見</button>
+        <button onclick="window.close()">再見</button>
     </div>
 
 
     <script>
-        const main = document.querySelector("main");
-        const input = document.getElementById("dataInput");
+        const main = document.querySelector('main');
+        const input = document.getElementById('dataInput');
         function saveDataInCookie() {
             event.preventDefault();
-            var expiryDate = new Date();
+            let expiryDate = new Date();
             expiryDate.setFullYear(expiryDate.getFullYear() + 1);
             document.cookie = `userData=${encodeURIComponent(input.value)}; expires=${expiryDate.toUTCString()};SameSite=None;Secure;`;
-            var submit = document.getElementById("submit");
+            let submit = document.getElementById('submit');
             submit.disabled = true;
-            document.querySelector("h1").innerText = "傳送中...";
-            main.classList.add("sending");
+            document.querySelector('h1').innerText = '傳送中……';
+            main.classList.add('sending');
             const url = `https://script.google.com/macros/s/AKfycbwZK-Ode5UnYWrfCn9bRi31-D64GgixunrFEDKEdvlu3sKANGeDfgnIFhtdeloeaDyQkw/exec?form=簽到&data=["${q}","${input.value}"]`;
             fetch(url)
                 .then(function (response) {
-                    main.classList.add("sent");
-                    main.classList.remove("sending");
+                    main.classList.add('sent');
+                    main.classList.remove('sending');
                     submit.disabled = false;
                 })
                 .catch(function (error) {
-                    submit.innerHTML = "我沒有get到，請再試一次";
+                    submit.innerHTML = '我沒有 get 到，請再試一次。';
                     submit.disabled = false;
                 });
         }
 
         function checkForCookie() {
-            var cookies = document.cookie.split(';');
-            for (var i = 0; i < cookies.length; i++) {
-                var cookie = cookies[i].trim();
-                if (cookie.startsWith("userData=")) {
-                    var userData = decodeURIComponent(cookie.substring("userData=".length));
+            const cookies = document.cookie.split(';');
+            for (const cookie of cookies) {
+                if (cookie.startsWith('userData=')) {
+                    const userData = decodeURIComponent(cookie.substring('userData='.length));
                     input.value = userData;
                     break;
                 }
@@ -207,17 +208,15 @@
 
         // Check for the cookie when the page loads
         checkForCookie();
-        //read property q from url and display
+        // Read property q from url and display
         const urlParams = new URLSearchParams(window.location.search);
         const q = urlParams.get('q');
         if (q) {
-            document.querySelector("h1").innerText = q;
+            document.querySelector('h1').innerText = q;
         } else {
-            document.querySelector("h1").innerText = "簽到";
+            document.querySelector('h1').innerText = '簽到';
         }
     </script>
-    </script>
-
 </body>
 
 </html>

--- a/form/2023-web-design/index.html
+++ b/form/2023-web-design/index.html
@@ -4,8 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>主題課程:網頁設計</title>
+    <title>主題課程：網頁設計</title>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100;300;400;500;700;900&display=swap');
+
         * {
             margin: 0;
             padding: 0;
@@ -14,7 +16,7 @@
 
         body {
             background-color: #ecf0f3;
-            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            font-family: 'Noto Sans TC', '微軟正黑體', sans-serif;
         }
 
         main {
@@ -138,46 +140,44 @@
     <main class="sending">
         <div class="circle"></div>
         <div class="circle c2"></div>
-        <h1>中電會10月主題課程: 網頁設計</h1>
-        <p>想要成為一位網頁設計大師嗎？這個10月，中電會為您帶來了一個絕佳的機會！我們誠摯邀請您參加我們的主題課程，
+        <h1>中電會 10 月主題課程：網頁設計</h1>
+        <p>想要成為一位網頁設計大師嗎？這個10月，中電會為您帶來了一個絕佳的機會！
+            我們誠摯邀請您參加我們的主題課程，在這個課程中，您將學會使用 HTML、CSS 等前端技術來開發互動式網頁，
+            並學會將自己的網站部署到線上伺服器。讓您了解背後的原理，獲得網頁設計技能，並應用在網路安全等各領域。
         </p>
-        <p>
-            在這個課程中，您將學會使用HTML、CSS等前端技術來開發互動式網頁，並學會將自己的網站部署到線上伺服器。讓你了解背後的原理，獲得網頁設計技能，並應用在網路安全等各領域。</p>
-        <div class="dis"><b>結業條件：</b> 期限內繳交每次簡單課堂作業</div>
-
-        <label for="name">姓名</label>
-        <input class="form__input" type="text" placeholder="如: 張三" id="name">
-        <label for="classNo">學校</label>
-        <input class="form__input" type="text" placeholder="如: 台中一中" id="classNo">
-        <label for="wish">E-Mail (寄送課程連結及證書)</label>
-        <input class="form__input" type="email" placeholder="" id="wish">
-        <button onclick="submit()" id="submit">提交</button>
+        <div class="dis"><b>結業條件：</b>期限內繳交每次簡單課堂作業</div>
+        <form onsubmit="return false">
+            <label for="name">姓名</label>
+            <input type="text" placeholder="如：張三" id="name" autocomplete="name">
+            <label for="classNo">學校</label>
+            <input type="text" placeholder="如：台中一中" id="classNo" autocomplete="work">
+            <label for="wish">E-Mail（寄送課程連結及證書）</label>
+            <input type="email" placeholder="" id="wish">
+            <button onclick="submit()" id="submitButton" type="button">提交</button>
+        </form>
     </main>
     <script>
-        const submit = () => {
-            event.preventDefault();
-            var submit = document.getElementById("submit");
+        function submit() {
+            const submit = document.getElementById('submitButton');
             submit.disabled = true;
-            submit.innerHTML = "傳送中...深呼吸...";
-            submit.style.backgroundColor = "#4B70E2";
-            const name = document.getElementById("name").value;
-            const classNo = document.getElementById("classNo").value;
-            const wish = document.getElementById("wish").value;
+            submit.innerHTML = '傳送中……深呼吸……';
+            submit.style.backgroundColor = '#4B70E2';
+            const name = document.getElementById('name').value;
+            const classNo = document.getElementById('classNo').value;
+            const wish = document.getElementById('wish').value;
             const url = `https://script.google.com/macros/s/AKfycbwZK-Ode5UnYWrfCn9bRi31-D64GgixunrFEDKEdvlu3sKANGeDfgnIFhtdeloeaDyQkw/exec?form=SCAICT-web-design&data=["${name}","${classNo}","${wish}"]`;
             fetch(url)
                 .then(function (response) {
-                    submit.innerHTML = "收到啦！";
-                    submit.style.backgroundColor = "#5be23f";
+                    submit.innerHTML = '收到啦！';
+                    submit.style.backgroundColor = '#5be23f';
                     submit.disabled = false;
                 })
                 .catch(function (error) {
-                    submit.innerHTML = "我沒有get到，請再試一次";
+                    submit.innerHTML = '我沒有 get 到，請再試一次。';
                     submit.disabled = false;
                 });
-
-
+            return false;
         }
-
     </script>
 </body>
 

--- a/form/2023-web-design/meet/index.html
+++ b/form/2023-web-design/meet/index.html
@@ -2,30 +2,30 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-    <style>
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
 
-body {
-    background-color: #000;
-    color: #fff;
-    font-family: 'Roboto', sans-serif;
-    font-size: 3rem;
-    text-align: center;
-}
-    </style>
+    body {
+      background-color: #000;
+      color: #fff;
+      font-family: 'Roboto', sans-serif;
+      font-size: 3rem;
+      text-align: center;
+    }
+  </style>
 </head>
 
 <body>
   <br>
-    <a href=https://meet.jit.si/%E4%B8%AD%E9%9B%BB%E6%9C%83%E4%B8%BB%E9%A1%8C%E8%AA%B2%E7%A8%8B%E7%B6%B2%E9%A0%81%E8%A8%AD%E8%A8%88 target=_blank >中電會10月主題課程: 網頁設計</a>
-<br>
-<script>
+  <a href=https://meet.jit.si/%E4%B8%AD%E9%9B%BB%E6%9C%83%E4%B8%BB%E9%A1%8C%E8%AA%B2%E7%A8%8B%E7%B6%B2%E9%A0%81%E8%A8%AD%E8%A8%88
+    target=_blank>中電會 10 月主題課程：網頁設計</a>
+  <br>
+  <script>
     window.location.href = "https://meet.jit.si/%E4%B8%AD%E9%9B%BB%E6%9C%83%E4%B8%BB%E9%A1%8C%E8%AA%B2%E7%A8%8B%E7%B6%B2%E9%A0%81%E8%A8%AD%E8%A8%88";
-
-</script>
+  </script>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -2,479 +2,374 @@
 
 <!DOCTYPE html>
 <html lang="zh-TW">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>SCAICT 中部高中電資社團聯合會議</title>
-        <meta name="theme-color" content="#2f4154" />
-        <meta
-            name="description"
-            content="中部高中電資社團聯合會議 Student's Clubs Alliance of Information in Central Taiwan，簡稱SCAICT 中電會是新創的中部地區在地高中職學生資訊組織。我們會準備很多的資安，演算法、人工智慧活動，都是針對0基礎的主題式教育"
-        />
-        <meta name="author" content="毛哥EM" />
 
-        <meta name="keywords" content="中部電資聯合會議, 中電會, SCAICT" />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="SCAICT 中部電資聯合會議" />
-        <meta property="og:url" content="https://scaict.org" />
-        <meta property="og:site_name" content="SCAICT 中部電資聯合會議" />
-        <meta
-            property="og:description"
-            content="中部高中電資聯合會議 Student's Clubs Alliance of Information in Central Taiwan，簡稱SCAICT 中電會是新創的中部地區在地高中職學生資訊組織。我們會準備很多的資安，演算法、人工智慧活動，都是針對0基礎的主題式教育"
-        />
-        <meta property="og:locale" content="zh-TW" />
-        <link
-            rel="apple-touch-icon"
-            sizes="180x180"
-            href="/src/img/apple-touch-icon.png"
-        />
-        <link
-            rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="/src/img/favicon-32x32.png"
-        />
-        <link
-            rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="/src/img/favicon-16x16.png"
-        />
-        <link rel="manifest" href="/src/img/site.webmanifest" />
-        <link
-            rel="mask-icon"
-            href="/src/img/safari-pinned-tab.svg"
-            color="#ca4480"
-        />
-        <meta name="msapplication-TileColor" content="#2b5797" />
-        <meta name="theme-color" content="#ffffff" />
-        <link rel="stylesheet" href="src/style.css" />
-        <script
-            src="https://kit.fontawesome.com/ca1af7f37f.js"
-            crossorigin="anonymous"
-        ></script>
-        <!-- Google tag (gtag.js) -->
-        <script
-            async
-            src="https://www.googletagmanager.com/gtag/js?id=G-F4MZSTYBW8"
-        ></script>
-        <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag() {
-                dataLayer.push(arguments);
-            }
-            gtag("js", new Date());
-            gtag("config", "G-F4MZSTYBW8");
-        </script>
-    </head>
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SCAICT 中部高中電資社團聯合會議</title>
+    <meta name="theme-color" content="#2f4154" />
+    <meta name="description"
+        content="中部高中電資社團聯合會議 Student's Clubs Alliance of Information in Central Taiwan，簡稱 SCAICT 中電會是新創的中部地區在地高中職學生資訊組織。我們會準備很多的資安，演算法、人工智慧活動，都是針對 0 基礎的主題式教育" />
+    <meta name="author" content="毛哥EM" />
 
-    <body>
-        <input type="checkbox" name="" id="credits" />
-        <main>
-         
-            <header>
-                <div>   <div class="background"></div>
+    <meta name="keywords" content="中部電資聯合會議, 中電會, SCAICT" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="SCAICT 中部電資聯合會議" />
+    <meta property="og:url" content="https://scaict.org" />
+    <meta property="og:site_name" content="SCAICT 中部電資聯合會議" />
+    <meta property="og:description"
+        content="中部高中電資聯合會議 Student's Clubs Alliance of Information in Central Taiwan，簡稱 SCAICT 中電會是新創的中部地區在地高中職學生資訊組織。我們會準備很多的資安，演算法、人工智慧活動，都是針對 0 基礎的主題式教育" />
+    <meta property="og:locale" content="zh-TW" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/src/img/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/src/img/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/src/img/favicon-16x16.png" />
+    <link rel="manifest" href="/src/img/site.webmanifest" />
+    <link rel="mask-icon" href="/src/img/safari-pinned-tab.svg" color="#ca4480" />
+    <meta name="msapplication-TileColor" content="#2b5797" />
+    <meta name="theme-color" content="#ffffff" />
+    <link rel="stylesheet" href="src/style.css" />
+    <script src="https://kit.fontawesome.com/ca1af7f37f.js" crossorigin="anonymous"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-F4MZSTYBW8"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+        gtag("js", new Date());
+        gtag("config", "G-F4MZSTYBW8");
+    </script>
+</head>
+
+<body>
+    <input type="checkbox" name="" id="credits" />
+    <main>
+
+        <header>
+            <div>
+                <div class="background"></div>
                 <div class="background-center"></div>
-                    <h1>中部高中電資社團聯合會議</h1>
-                    <h2>
-                        Student Club's Association of Information in Central
-                        Taiwan
-                    </h2>
-                    <div class="lcd">_</div>
-                    <div class="lcdText">Learn More</div>
-                    <a href="" id="lcdLink">
-                        <div class="lcdButton"></div>
-                    </a>
-                    <div class="ukraine"></div>
-                    <div class="ukraineText">Hue</div>
-                    <div class="ukraineText ukraineBrightness">Brightness</div>
-                    <div class="ukraine" id="ukraineBrightness"></div>
-                    <div class="bHole"></div>
-                    <div
-                        class="charger"
-                        onclick="document.body.style.opacity=0"
-                    ></div>
-                    <div class="chargerText">Sponsor</div>
-                    <div
-                        class="cpu"
-                        onclick="document.querySelector('.cpu img').style.animation='jump .5s ease-in-out';setTimeout(function() {document.querySelector('.cpu img').style.animation=''}, 500);"
-                    >
-                        <img src="/src/img/logo.svg" alt="" />
-                    </div>
-                    <div class="scaict">SCAICT</div>
-                    <div class="friend">
-                        <a href="https://www.instagram.com/scint.tw/">SCINT</a
-                        ><br />
-                        <a href="/">SCAICT</a><br />
-                        <a href="https://scist.org/">SCIST</a>
-                    </div>
-                    <div class="motor"></div>
-                    <input type="checkbox" id="motorSwitch" />
-                    <label class="switch" for="motorSwitch"></label>
-                    <div class="switchToggle"></div>
-                    <div class="switchText">Motor</div>
-                    <div class="spinner"></div>
-                    <div class="spinnerText">Scroll Down</div>
-                    <div class="line"></div>
-                    <div class="resistance"></div>
-                    <div class="sca1"></div>
-                    <div class="diode"></div>
-                    <div class="chip"></div>
-                    <a href="#About_" class="button About"></a>
-                    <h3 class="About">About</h3>
-                    <a href="#Events_" class="button Events"></a>
-                    <h3 class="Events">Events</h3>
-                    <a href="#Project_" class="button Project"></a>
-                    <h3 class="Project">Project</h3>
-                    <a href="#Social_" class="button Social"></a>
-                    <h3 class="Social">Social</h3>
+                <h1>中部高中電資社團聯合會議</h1>
+                <h2>
+                    Student Club's Association of Information in Central
+                    Taiwan
+                </h2>
+                <div class="lcd">_</div>
+                <div class="lcdText">Learn More</div>
+                <a href="" id="lcdLink">
+                    <div class="lcdButton"></div>
+                </a>
+                <div class="ukraine"></div>
+                <div class="ukraineText">Hue</div>
+                <div class="ukraineText ukraineBrightness">Brightness</div>
+                <div class="ukraine" id="ukraineBrightness"></div>
+                <div class="bHole"></div>
+                <div class="charger" onclick="document.body.style.opacity=0"></div>
+                <div class="chargerText">Sponsor</div>
+                <div class="cpu"
+                    onclick="document.querySelector('.cpu img').style.animation='jump .5s ease-in-out';setTimeout(function() {document.querySelector('.cpu img').style.animation=''}, 500);">
+                    <img src="/src/img/logo.svg" alt="" />
                 </div>
-            </header>
-            <section id="About">
-                <div class="container">
-                    <div class="before-goals">
-                        <div class="titleBox cpuLogo">
-                            <h2>關於我們</h2>
-                            <h3>About Us</h3>
-                        </div>
-                        <div class="introduction">
-                            <h3>中部高中電資社團聯合會議</h3>
+                <div class="scaict">SCAICT</div>
+                <div class="friend">
+                    <a href="https://www.instagram.com/scint.tw/">SCINT</a><br />
+                    <a href="/">SCAICT</a><br />
+                    <a href="https://scist.org/">SCIST</a>
+                </div>
+                <div class="motor"></div>
+                <input type="checkbox" id="motorSwitch" />
+                <label class="switch" for="motorSwitch"></label>
+                <div class="switchToggle"></div>
+                <div class="switchText">Motor</div>
+                <div class="spinner"></div>
+                <div class="spinnerText">Scroll Down</div>
+                <div class="line"></div>
+                <div class="resistance"></div>
+                <div class="sca1"></div>
+                <div class="diode"></div>
+                <div class="chip"></div>
+                <a href="#About_" class="button About"></a>
+                <h3 class="About">About</h3>
+                <a href="#Events_" class="button Events"></a>
+                <h3 class="Events">Events</h3>
+                <a href="#Project_" class="button Project"></a>
+                <h3 class="Project">Project</h3>
+                <a href="#Social_" class="button Social"></a>
+                <h3 class="Social">Social</h3>
+            </div>
+        </header>
+        <section id="About">
+            <div class="container">
+                <div class="before-goals">
+                    <div class="titleBox cpuLogo">
+                        <h2>關於我們</h2>
+                        <h3>About Us</h3>
+                    </div>
+                    <div class="introduction">
+                        <h3>中部高中電資社團聯合會議</h3>
+                        <p>
+                            成立於2021年，是由一群熱愛資訊科技和社團活動的高中職生所組成，而主要目的在於整合中部資訊科技資源，推廣資訊相關的課程。
+                            本學期目前規劃邀請各大講師來線上授課，且學員可以免費且自由報名。
+                        </p>
+                        <p lang="en-US">
+                            Established in 2021, we are formed by a group of
+                            high school students passionate about
+                            information technology and community activities.
+                            Our main goal is to integrate information
+                            technology resources in the central region and
+                            promote courses related to information
+                            technology.
+                        </p>
+                    </div>
+                    <div class="introImg"></div>
+                </div>
+                <div class="titleBox goal" id="Project">
+                    <div>
+                        <h2>團隊目標</h2>
+                        <h3>Our Goals</h3>
+                        <p>我們有以下目標，對，然後，就這樣。</p>
+                    </div>
+                    <div class="space"></div>
+                    <div class="goals">
+                        <article>
+                            <img src="" alt="" />
+                            <h4>開放原始碼社群</h4>
                             <p>
-                                成立於2021年，是由一群熱愛資訊科技和社團活動的高中職生所組成，而主要目的在於整合中部資訊科技資源，推廣資訊相關的課程。本學期目前規劃邀請各大講師來線上授課，且學員可以免費且自由報名。
+                                我們是一個開放原始碼社群，並且與開放文化基金會（OCF）
+                                合作，透過公開課程簡報、影片及網站原始碼給大家更自由的使用我們的資源。
                             </p>
-                            <p lang="en-US">
-                                Established in 2021, we are formed by a group of
-                                high school students passionate about
-                                information technology and community activities.
-                                Our main goal is to integrate information
-                                technology resources in the central region and
-                                promote courses related to information
-                                technology.
+                        </article>
+                        <article>
+                            <img src="" alt="" />
+                            <h4>主題課程</h4>
+                            <p>
+                                在每個月都會有不同主題的主題課程，大多以免費、線上的課程來進行授課。
+                                若是時間上有衝突也無妨，我們都會在官方
+                                YouTube 頻道放上先前的課程內容喔！
                             </p>
-                        </div>
-                        <div class="introImg"></div>
+                        </article>
+                        <article>
+                            <img src="" alt="" />
+                            <h4>創社</h4>
+                            <p>
+                                協助中部地區學校創立或復興電資類型社團。
+                                以零成本、零壓力為目標，只要推派社團幹部，我們就會盡全力的幫忙。
+                            </p>
+                        </article>
                     </div>
-                    <div class="titleBox goal" id="Project">
-                        <div>
-                            <h2>團隊目標</h2>
-                            <h3>Our Goals</h3>
-                            <p>我們有以下目標，對，然後，就這樣。</p>
-                        </div>
-                        <div class="space"></div>
-                        <div class="goals">
-                            <article>
-                                <img src="" alt="" />
-                                <h4>開源社群</h4>
-                                <p>
-                                    我們是一個開源社群，並且有與 OCF
-                                    合作，透過公開課程簡報、影片及網站原始碼給大家更自由的使用我們的資源
-                                </p>
-                            </article>
-                            <article>
-                                <img src="" alt="" />
-                                <h4>主題課程</h4>
-                                <p>
-                                    在每個月都會有不同主題的主題課程，大多以免費、線上的課程來進行教學。
-                                    若是時間上有衝突也無妨，我們都會在中電會的官方
-                                    YT 頻道放上之前課程內容喔！
-                                </p>
-                            </article>
-                            <article>
-                                <img src="" alt="" />
-                                <h4>創社 Pioneer</h4>
-                                <p>
-                                    協助中部地區學校創立/復興電資類型社團。以零成本、零壓力為目標，只要推派社團幹部，我們就會盡全力的幫忙。
-                                </p>
-                            </article>
-                        </div>
+                </div>
+                <section id="Events">
+                    <h2>近期活動</h2>
+                    <h3>Recent Events</h3>
+                    <div class="events"></div>
+                </section>
+                <section id="Pastevents">
+                    <h2>過去活動</h2>
+                    <h3>Past Events</h3>
+                    <div class="sdReader"></div>
+                    <div class="sd"></div>
+                    <div class="sdReaderTop"></div>
+                    <div class="cpuMem">
+                        <img src="/src/img/logo.svg" />
                     </div>
-                    <section id="Events">
-                        <h2>近期活動</h2>
-                        <h3>Recent Events</h3>
-                        <div class="events"></div>
-                    </section>
-                    <section id="Pastevents">
-                        <h2>過去活動</h2>
-                        <h3>Past Events</h3>
-                        <div class="sdReader"></div>
-                        <div class="sd"></div>
-                        <div class="sdReaderTop"></div>
-                        <div class="cpuMem">
-                            <img src="/src/img/logo.svg" />
-                        </div>
-                        <div class="imgButton" onclick="changeImg(-1)"></div>
-                        <div
-                            class="imgButton right"
-                            onclick="changeImg()"
-                        ></div>
-                        <div class="imgLcd"></div>
-                        <div id="showImg-container">
-                            <div class="showImg original">選擇一個 SD 回憶播放<br>Select a SD Memory to play</div>
-                        </div>
+                    <div class="imgButton" onclick="changeImg(-1)"></div>
+                    <div class="imgButton right" onclick="changeImg()"></div>
+                    <div class="imgLcd"></div>
+                    <div id="showImg-container">
+                        <div class="showImg original">選擇一個 SD 卡播放回憶<br>Select a SD card to play</div>
+                    </div>
 
-                        <div class="sdContainer">
-                            <div class="sdBox"></div>
-                        </div>
-                    </section>
-                    <section id="Sponsor">
-                        <div class="SponsorBoxForHeight">
-                            <h2>充電夥伴</h2>
-                            <h3>Sponsors</h3>
-                            <div class="Sponsor-ccontainer">
-                                <div class="sponsor-fixed"></div>
-                                <div class="sponsor-relative">
-                                    <div class="sponsor-list">
-                                        <!-- @format -->
+                    <div class="sdContainer">
+                        <div class="sdBox"></div>
+                    </div>
+                </section>
+                <section id="Sponsor">
+                    <div class="SponsorBoxForHeight">
+                        <h2>充電夥伴</h2>
+                        <h3>Sponsors</h3>
+                        <div class="Sponsor-ccontainer">
+                            <div class="sponsor-fixed"></div>
+                            <div class="sponsor-relative">
+                                <div class="sponsor-list">
+                                    <!-- @format -->
 
-                                        <div class="sponsor">
-                                            <div class="battery-gogoro">
-                                                Venue<br />provided
+                                    <div class="sponsor">
+                                        <div class="battery-gogoro">
+                                            Venue<br />provided
+                                        </div>
+                                        <a href="https://tcivs.tc.edu.tw/" target="_blank">
+                                            <img src="https://upload.wikimedia.org/wikipedia/zh/3/35/Logo_TCIVS.gif"
+                                                alt="台中高工 Logo" />
+                                            <div>
+                                                <h4>台中高工</h4>
+                                                <p>
+                                                    國內工業教育指標學府，人才輩出。歷屆畢業校友近 5 萬人分佈海內外。
+                                                    無論在政府機構、學術界、公民營企業或成功創業，皆卓然有成，
+                                                    尤其培育出技術菁英多數投入產業界，或為產業界之金字品牌，享譽社會。
+                                                </p>
                                             </div>
-                                            <a
-                                                href="https://tcivs.tc.edu.tw/"
-                                                target="_blank"
-                                            >
-                                                <img
-                                                    src="https://upload.wikimedia.org/wikipedia/zh/3/35/Logo_TCIVS.gif"
-                                                    alt="台中高工 Logo"
-                                                />
-                                                <div>
-                                                    <h4>台中高工</h4>
-                                                    <p>
-                                                        國內工業教育指標學府，人才輩出。歷屆畢業校友近5萬人，分佈海內外，無論在政府機構、學術界、公民營企業或成功創業，皆卓然有成，尤其培育出技術菁英多數投入產業界，或為產業界之金字品牌，享譽社會。
-                                                    </p>
-                                                </div></a
-                                            >
-                                        </div>
-                                        <div class="sponsor">
-                                            <div class="battery-9v">
-                                                PRENIUM<br />SPONSOR
-                                            </div>
-                                            <a
-                                                href="https://ais3.org/"
-                                                target="_blank"
-                                            >
-                                                <img
-                                                    src="https://ais3.org/img/AIS3logo.png"
-                                                    alt="AIS3 Logo"
-                                                />
-                                                <div>
-                                                    <h4>AIS3</h4>
-                                                    <p>
-                                                        邀請具資安實務與國際資安競賽實戰經驗之國內外專家學者進行授課，透過資訊安全實務(或實戰)之經驗分享與演練，提升本課程學員之資安實務的能力與深度。
-                                                    </p>
-                                                </div>
-                                            </a>
-                                        </div>
-                                        <div class="sponsor">
-                                            <div class="battery-9v">
-                                                PRENIUM<br />SPONSOR
-                                            </div>
-                                            <a
-                                                href="https://devco.re/"
-                                                target="_blank"
-                                            >
-                                                <img
-                                                    src="/src/img/devcore.png"
-                                                    alt="Devcore Logo"
-                                                    style="
-                                                        transform: scale(1.34);
-                                                    "
-                                                />
-                                                <div>
-                                                    <h4>DEVCORE 戴夫寇爾</h4>
-                                                    <p>
-                                                        DEVCORE
-                                                        是一家由資安專家組成的台灣資安公司，專注於提供「紅隊演練」服務。以挑戰極限、研發攻擊技巧為核心，致力於成為企業堅強的資安後盾，為世界打造更安全的網路環境。
-                                                    </p>
-                                                </div></a
-                                            >
-                                        </div>
-                                        <div class="sponsor">
-                                            <div class="battery">SPONSOR</div>
-                                            <a
-                                                href="https://ncse.tw/"
-                                                target="_blank"
-                                            >
-                                                <img
-                                                    src="https://ncse.tw/assets/img/logo.png"
-                                                    alt="NCSE Logo"
-                                                />
-                                                <div>
-                                                    <h4>NCSE NETWORK</h4>
-                                                    <p>
-                                                        我們致力於提供高品質的雲端服務，服務範圍包含各類伺服器租用、網站代管、攻擊流量洗清(Anti-DDoS)、技術支援，完美契合各類使用場景，並結合三大特點提供全方位的支援！
-                                                    </p>
-                                                </div></a
-                                            >
-                                        </div>
-                                        <div class="sponsor">
-                                            <div class="battery-gogoro">
-                                                SPECIAL<br />THANKS
-                                            </div>
-                                            <a
-                                                href="https://ocf.tw/"
-                                                target="_blank"
-                                            >
-                                                <img
-                                                    class="invert"
-                                                    src="https://ocf.tw/mediakit/icon_white.png"
-                                                    alt="OCF Logo"
-                                                    style="
-                                                        transform: scale(0.8);
-                                                    "
-                                                />
-                                                <div>
-                                                    <h4>開放文化基金會 OCF</h4>
-                                                    <p>
-                                                        是一個非營利性的組織。透過推廣開放科技和跨界合作，在台灣持續的銜繫科技社群與其他公／私領域，來促成開放共創保障數位人權、支持透明涵融的數位公民社會。
-                                                    </p>
-                                                </div></a
-                                            >
-                                        </div>
+                                        </a>
                                     </div>
-                                    <div class="sponsor-club">
-                                        <h2 id="clubTitle">參與社團</h2>
-                                        <h3>Participate clubs</h3>
-                                        <div class="club-list">
-                                            <a href=""
-                                                ><img
-                                                    src="/src/img/club/SYSH_MAKER2.webp"
-                                                    alt=""
-                                            /></a>
-                                            <a href=""
-                                                ><img
-                                                    src="/src/img/club/TCIRC.webp"
-                                                    alt=""
-                                            /></a>
-                                            <a href=""
-                                                ><img
-                                                    src="/src/img/club/WHCS.webp"
-                                                    alt=""
-                                            /></a>
+                                    <div class="sponsor">
+                                        <div class="battery-9v">
+                                            PREMIUM<br />SPONSOR
                                         </div>
+                                        <a href="https://ais3.org/" target="_blank">
+                                            <img src="https://ais3.org/img/AIS3logo.png" alt="AIS3 Logo" />
+                                            <div>
+                                                <h4>AIS3</h4>
+                                                <p>
+                                                    邀請具資安實務與國際資安競賽實戰經驗之國內外專家學者進行授課，
+                                                    透過資訊安全實務或實戰之經驗分享與演練，提升本課程學員之資安實務的能力與深度。
+                                                </p>
+                                            </div>
+                                        </a>
+                                    </div>
+                                    <div class="sponsor">
+                                        <div class="battery-9v">
+                                            PREMIUM<br />SPONSOR
+                                        </div>
+                                        <a href="https://devco.re/" target="_blank">
+                                            <img src="/src/img/devcore.png" alt="Devcore Logo" style="
+                                                        transform: scale(1.34);
+                                                    " />
+                                            <div>
+                                                <h4>DEVCORE 戴夫寇爾</h4>
+                                                <p>
+                                                    DEVCORE 是一家由資安專家組成的台灣資安公司，
+                                                    專注於提供「紅隊演練」服務。以挑戰極限、研發攻擊技巧為核心，
+                                                    致力於成為企業堅強的資安後盾，為世界打造更安全的網路環境。
+                                                </p>
+                                            </div>
+                                        </a>
+                                    </div>
+                                    <div class="sponsor">
+                                        <div class="battery">SPONSOR</div>
+                                        <a href="https://ncse.tw/" target="_blank">
+                                            <img src="https://ncse.tw/assets/img/logo.png" alt="NCSE Logo" />
+                                            <div>
+                                                <h4>NCSE NETWORK</h4>
+                                                <p>
+                                                    我們致力於提供高品質的雲端服務，服務範圍包含各類伺服器租用、網站代管、
+                                                    攻擊流量洗清（Anti-DDoS）、技術支援，完美契合各類使用場景，並結合三大特點提供全方位的支援！
+                                                </p>
+                                            </div>
+                                        </a>
+                                    </div>
+                                    <div class="sponsor">
+                                        <div class="battery-gogoro">
+                                            SPECIAL<br />THANKS
+                                        </div>
+                                        <a href="https://ocf.tw/" target="_blank">
+                                            <img class="invert" src="https://ocf.tw/mediakit/icon_white.png"
+                                                alt="OCF Logo" style="
+                                                        transform: scale(0.8);
+                                                    " />
+                                            <div>
+                                                <h4>開放文化基金會 OCF</h4>
+                                                <p>
+                                                    是一個非營利性的組織。透過推廣開放科技和跨界合作，在台灣持續的銜繫科技社群與其他公／私領域，
+                                                    來促成開放共創保障數位人權、支持透明涵融的數位公民社會。
+                                                </p>
+                                            </div>
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="sponsor-club">
+                                    <h2 id="clubTitle">參與社團</h2>
+                                    <h3>Participating clubs</h3>
+                                    <div class="club-list">
+                                        <a href=""><img src="/src/img/club/SYSH_MAKER2.webp" alt="" /></a>
+                                        <a href=""><img src="/src/img/club/TCIRC.webp" alt="" /></a>
+                                        <a href=""><img src="/src/img/club/WHCS.webp" alt="" /></a>
                                     </div>
                                 </div>
                             </div>
-                            <div class="sponsor-join">
+                        </div>
+                        <div class="sponsor-join">
+                            <div>
+                                <h2>一起充電吧！</h2>
+                                <h3>You are the missing one!</h3>
+                                <p>
+                                    電池還缺你一個！<br />
+                                    你的贊助能讓中電會提供更多優質的資源和更多豐富的課程與活動。<br />
+                                    若你有任何資源想要分享歡迎聯絡我們。
+                                </p>
+                                <p lang="en-US">
+                                    Your support can help us provide more
+                                    high-quality resources and a richer
+                                    variety of courses and activities. If
+                                    you have any resources you'd like to
+                                    share, feel free to contact us.
+                                </p>
+                            </div>
+                            <img src="/src/img/battery-case.svg" alt="" class="batteryCase" />
+                        </div>
+                        <div class="treebox">
+                            <div>
+                                <img src="/src/img/arrow.svg" alt="" class="arrow" />
                                 <div>
-                                    <h2>一起充電吧!</h2>
-                                    <h3>You are the missing one!</h3>
                                     <p>
-                                        電池還缺你一個!
-                                        <br />
-                                        你的贊助能讓中電會提供更多U質的資源和更多豐富的課程與活動。
-                                        <br />
-                                        若你有任何資源想要分享歡迎聯絡我們。
+                                        歡迎追蹤我們<br />以在第一時間獲得最新活動資訊。
                                     </p>
                                     <p lang="en-US">
-                                        Your support can help us provide more
-                                        high-quality resources and a richer
-                                        variety of courses and activities. If
-                                        you have any resources you'd like to
-                                        share, feel free to contact us.
+                                        Follow us to get the latest updates.
                                     </p>
                                 </div>
-                                <img
-                                    src="/src/img/battery-case.svg"
-                                    alt=""
-                                    class="batteryCase"
-                                />
                             </div>
-                            <div class="treebox">
-                                <div>
-                                    <img
-                                        src="/src/img/arrow.svg"
-                                        alt=""
-                                        class="arrow"
-                                    />
-                                    <div>
-                                        <p>
-                                            歡迎追蹤我們<br />以在第一時間獲得最新活動資訊
-                                        </p>
-                                        <p lang="en-US">
-                                            Follow us to get the latest updates.
-                                        </p>
-                                    </div>
-                                </div>
-                                <div class="tree">
-                                    <img
-                                        src="/src/img/logo.svg"
-                                        alt="Logo"
-                                        class="logo"
-                                    />
-                                    <i
-                                        class="fa-brands fa-facebook"
-                                        link="https://www.facebook.com/scaict.tw/"
-                                    ></i>
-                                    <i
-                                        class="fa-brands fa-discord"
-                                        link="https://discord.gg/neQ7QEUcqe"
-                                    ></i>
-                                    <i
-                                        class="fa-brands fa-instagram"
-                                        link="https://www.instagram.com/scaict.tw/"
-                                    ></i>
-                                    <i
-                                        class="fa-regular fa-envelope"
-                                        link="mailto:scaict.official@gmail.com"
-                                    ></i>
-                                    <i
-                                        class="fa-brands fa-github"
-                                        link="https://github.com/SCAICT"
-                                    ></i>
-                                    <img src="/src/img/tree.svg" alt="" />
-                                </div>
-                            </div>
-                            <div class="braille">
-                                <label for="credits" class="creditsLabel">
-                                    <i class="fa-regular fa-copyright"></i
-                                ></label>
-                                ⠁⠯⠄⠕⠌⠐⠅⠩⠄⠁⠯⠄⠙⠞⠐⠓⠱⠄⠊⠮⠐⠋⠻⠂⠉⠞⠂⠗⠮⠂⠗⠫⠐⠡⠐⠀⠠⠎⠞⠥⠙⠑⠝⠞⠀⠠⠉⠇⠥⠃⠄⠎⠀⠠⠁⠎⠎⠕⠉⠊⠁⠞⠊⠕⠝⠀⠕⠋⠀⠠⠊⠝⠋⠕⠗⠍⠁⠞⠊⠕⠝⠀⠊⠝⠀⠠⠉⠑⠝⠞⠗⠁⠇⠀⠠⠞⠁⠊⠺⠁⠝⠀⠖⠐⠍⠭⠂⠛⠥⠂⠙⠞⠈⠓⠱⠐⠙⠮⠁⠑⠬⠈⠟⠜⠈⠃⠭⠂⠁⠮⠐⠨⠐⠤⠀⠛⠌⠂⠅⠒⠈⠝⠡⠈⠟⠜⠄⠑⠞⠐⠁⠮⠐⠅⠮⠐⠚⠺⠈⠙⠧⠐⠙⠮⠁⠗⠔⠐⠮⠂⠐⠐⠐⠅⠯⠄⠑⠡⠈⠝⠡⠈⠊⠱⠐⠉⠡⠐⠕⠌⠐⠚⠒⠐
+                            <div class="tree">
+                                <img src="/src/img/logo.svg" alt="Logo" class="logo" />
+                                <i class="fa-brands fa-facebook" link="https://www.facebook.com/scaict.tw/"></i>
+                                <i class="fa-brands fa-discord" link="https://discord.gg/neQ7QEUcqe"></i>
+                                <i class="fa-brands fa-instagram" link="https://www.instagram.com/scaict.tw/"></i>
+                                <i class="fa-regular fa-envelope" link="mailto:scaict.official@gmail.com"></i>
+                                <i class="fa-brands fa-github" link="https://github.com/SCAICT"></i>
+                                <img src="/src/img/tree.svg" alt="" />
                             </div>
                         </div>
-                    </section>
-                </div>
-            </section>
-            <div class="sponsor-charger fixed"></div>
-        </main>
-        <div class="reminder">請旋轉螢幕</div>
-        <section class="credits">
-            <div>
-                <label for="credits" class="credits-x">
-                    <i class="fa-regular fa-circle-xmark"></i
-                ></label>
-                <h2>Credits</h2>
-                <div>
-                    Front-End: 毛哥EM<br />
-                    Back-End: Edit Mr.<br />
-                    Design: Elvis Mao<br />
-
-                    Font:
-                    <a href="http://nicofont.pupu.jp/nicomoji.html">NicoMoji</a
-                    >,
-                    <a
-                        href="https://github.com/andrew-paglinawan/QuicksandFamily"
-                        >Quicksand</a
-                    >, <a href="https://justfont.com/huninn/">jf open 粉圓</a>
-                    <footer>
-                        Copyright © 2023 SCAICT All Rights Reserved<br />
-                        If you have any questions, please contact us at
-                        <a href="mailto:scaict.official@gmail.com"
-                            >scaict.official@gmail.com</a
-                        >
-                    </footer>
-                </div>
+                        <div class="braille">
+                            <label for="credits" class="creditsLabel">
+                                <i class="fa-regular fa-copyright"></i></label>
+                            ⠁⠯⠄⠕⠌⠐⠅⠩⠄⠁⠯⠄⠙⠞⠐⠓⠱⠄⠊⠮⠐⠋⠻⠂⠉⠞⠂⠗⠮⠂⠗⠫⠐⠡⠐⠀⠠⠎⠞⠥⠙⠑⠝⠞⠀⠠⠉⠇⠥⠃⠄⠎⠀⠠⠁⠎⠎⠕⠉⠊⠁⠞⠊⠕⠝⠀⠕⠋⠀⠠⠊⠝⠋⠕⠗⠍⠁⠞⠊⠕⠝⠀⠊⠝⠀⠠⠉⠑⠝⠞⠗⠁⠇⠀⠠⠞⠁⠊⠺⠁⠝⠀⠖⠐⠍⠭⠂⠛⠥⠂⠙⠞⠈⠓⠱⠐⠙⠮⠁⠑⠬⠈⠟⠜⠈⠃⠭⠂⠁⠮⠐⠨⠐⠤⠀⠛⠌⠂⠅⠒⠈⠝⠡⠈⠟⠜⠄⠑⠞⠐⠁⠮⠐⠅⠮⠐⠚⠺⠈⠙⠧⠐⠙⠮⠁⠗⠔⠐⠮⠂⠐⠐⠐⠅⠯⠄⠑⠡⠈⠝⠡⠈⠊⠱⠐⠉⠡⠐⠕⠌⠐⠚⠒⠐
+                        </div>
+                    </div>
+                </section>
             </div>
         </section>
-        <section class="link">
-            <div class="top-header"></div>
-            <div id="About_"></div>
-            <div id="Project_"></div>
-            <div id="Events_"></div>
+        <div class="sponsor-charger fixed"></div>
+    </main>
+    <div class="reminder">請旋轉螢幕。</div>
+    <section class="credits">
+        <div>
+            <label for="credits" class="credits-x">
+                <i class="fa-regular fa-circle-xmark"></i></label>
+            <h2>Credits</h2>
+            <div>
+                Front-End：毛哥EM<br />
+                Back-End：Edit Mr.<br />
+                Design：Elvis Mao<br />
 
-            <div id="Social_"></div>
-        </section>
-        <script src="src/main.js"></script>
-    </body>
+                Fonts:
+                <a href="http://nicofont.pupu.jp/nicomoji.html">NicoMoji</a>,
+                <a href="https://github.com/andrew-paglinawan/QuicksandFamily">Quicksand</a>, <a
+                    href="https://justfont.com/huninn/">jf open 粉圓</a>
+                <footer>
+                    Copyright © 2023 SCAICT All Rights Reserved<br />
+                    If you have any questions, please contact us at
+                    <a href="mailto:scaict.official@gmail.com">scaict.official@gmail.com</a>
+                </footer>
+            </div>
+        </div>
+    </section>
+    <section class="link">
+        <div class="top-header"></div>
+        <div id="About_"></div>
+        <div id="Project_"></div>
+        <div id="Events_"></div>
+
+        <div id="Social_"></div>
+    </section>
+    <script src="src/main.js"></script>
+</body>
+
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,97 +1,97 @@
 /** @format */
 
-fetch("https://raw.githubusercontent.com/SCAICT/website-data/main/home.json")
+fetch('https://raw.githubusercontent.com/SCAICT/website-data/main/home.json')
     .then(response => response.json())
     .then(data => {
-        document.querySelector(".lcd").innerHTML = data.lcd.text;
-        document.getElementById("lcdLink").href = data.lcd.link;
-        document.getElementById("lcdLink").target = "_blank";
+        document.querySelector('.lcd').innerHTML = data.lcd.text;
+        document.getElementById('lcdLink').href = data.lcd.link;
+        document.getElementById('lcdLink').target = '_blank';
     })
     .catch(error => {
-        console.error("Error: ", error);
+        console.error('Error: ', error);
     });
 
 // Events
-fetch("https://raw.githubusercontent.com/SCAICT/website-data/main/events.json")
+fetch('https://raw.githubusercontent.com/SCAICT/website-data/main/events.json')
     .then(response => response.json())
     .then(data => {
-        var events = data.activities;
-        var eventsHTML = "";
-        for (var i = 0; i < events.length; i++) {
+        const events = data.activities;
+        let eventsHTML = '';
+        for (const event of events) {
             eventsHTML += `
             <article>${
-                events[i].image != ""
-                    ? '<img src="' + events[i].image + '" />'
-                    : ""
-            }<div><h4>${events[i].title}</h4><h5>${
-                events[i].description
+                event.image != ''
+                    ? `<img src="${event.image}"/>`
+                    : ''
+            }<div><h4>${event.title}</h4><h5>${
+                event.description
             }</h5><ul><li><i class="fa-solid fa-calendar"></i> ${
-                events[i].date
+                event.date
             }</li><li><i class="fa-solid fa-location-dot"></i> ${
-                events[i].location
+                event.location
             }</li><li><i class="fa-solid fa-tag"></i> ${
-                events[i].price
+                event.price
             }</li></ul></div></article>`;
         }
-        document.querySelector(".events").innerHTML = eventsHTML;
+        document.querySelector('.events').innerHTML = eventsHTML;
     })
     .catch(error => {
-        console.error("Error:", error);
+        console.error('Error:', error);
     });
 
 // Images
 let imageData,
     pressed = false,
     imageIndex = 0;
-fetch("https://raw.githubusercontent.com/SCAICT/website-data/main/images.json")
+fetch('https://raw.githubusercontent.com/SCAICT/website-data/main/images.json')
     .then(response => response.json())
     .then(data => {
         imageData = data;
-        let sdBox = document.querySelector(".sdBox");
-        for (var event in imageData) {
-            var div = document.createElement("div");
-            div.classList.add("sdCard");
+        let sdBox = document.querySelector('.sdBox');
+        for (const event in imageData) {
+            const div = document.createElement('div');
+            div.classList.add('sdCard');
             div.textContent = event;
             sdBox.appendChild(div);
-            div.addEventListener("click", showImg);
+            div.addEventListener('click', showImg);
         }
     })
     .catch(error => {
-        console.error("Error: ", error);
+        console.error('Error: ', error);
     });
 
-const sd = document.querySelector(".sd");
-const imgContainer = document.getElementById("showImg-container");
+const sd = document.querySelector('.sd');
+const imgContainer = document.getElementById('showImg-container');
 const showImg = event => {
     if (pressed)
-        document.querySelector(".selected-sd").classList.remove("selected-sd");
+        document.querySelector('.selected-sd').classList.remove('selected-sd');
     else pressed = true;
-    var activityName = event.target.innerText;
-    event.target.classList.add("selected-sd");
-    sd.style.left = "-25vh";
+    const activityName = event.target.innerText;
+    event.target.classList.add('selected-sd');
+    sd.style.left = '-25vh';
     imgContainer.innerHTML = '<div class="showImg"></div>';
     imageIndex = 0;
     setTimeout(() => {
         sd.style.left = `calc(20vh / var(--h))`;
         setTimeout(() => {
-            imgContainer.innerHTML = "";
-            for (var i = 0; i < imageData[activityName].length; i++) {
-                var div = document.createElement("div");
-                div.classList.add("showImg");
+            imgContainer.innerHTML = '';
+            for (const i = 0; i < imageData[activityName].length; i++) {
+                const div = document.createElement('div');
+                div.classList.add('showImg');
                 div.style.backgroundImage = `url(https://raw.githubusercontent.com/SCAICT/website-data/main/converted/img/${activityName}/${imageData[activityName][i]})`;
                 imgContainer.appendChild(div);
             }
             document
-                .querySelector("#showImg-container .showImg:last-child")
-                .classList.add("displaying");
+                .querySelector('#showImg-container .showImg:last-child')
+                .classList.add('displaying');
         }, 500);
     }, 500);
     sd.innerText = activityName;
 };
 const changeImg = (direction = 1) => {
     document
-        .querySelector("#showImg-container .showImg.displaying")
-        .classList.remove("displaying");
+        .querySelector('#showImg-container .showImg.displaying')
+        .classList.remove('displaying');
     imageIndex += direction;
     if (imageIndex < 0) imageIndex = imageData[sd.innerText].length - 1;
     if (imageIndex >= imageData[sd.innerText].length) imageIndex = 0;
@@ -99,12 +99,12 @@ const changeImg = (direction = 1) => {
         .querySelector(
             `#showImg-container .showImg:nth-child(${imageIndex + 1})`
         )
-        .classList.add("displaying");
+        .classList.add('displaying');
 };
 
 // Mouse Move Effect
-const header = document.querySelector("header");
-header.addEventListener("mousemove", e => {
+const header = document.querySelector('header');
+header.addEventListener('mousemove', e => {
     const x = (e.clientX / window.innerWidth) * 10 - 5;
     const y = (e.clientY / window.innerHeight) * 10 - 5;
     header.style.transform = `translate(${-x}vh, ${-y}vh)`;
@@ -113,10 +113,10 @@ header.addEventListener("mousemove", e => {
 });
 
 // Device Orientation Effect
-var phone = /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+const phone = /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
     navigator.userAgent
 );
-var rotation = false,
+let rotation = false,
     x,
     y;
 function checkRotation() {
@@ -127,25 +127,25 @@ function checkRotation() {
         window.innerWidth +
         (window.innerHeight * 1.15) / 3;
     SponsorBoxForHeight = document.querySelector(
-        ".SponsorBoxForHeight"
+        '.SponsorBoxForHeight'
     ).offsetHeight;
     document.body.style.height =
         containerScrollWidth +
         SponsorBoxForHeight -
         parseFloat(getComputedStyle(document.documentElement).fontSize) * 3.5 +
-        "px";
-    document.getElementById("About_").style.height =
-        document.querySelector(".before-goals").offsetWidth + "px";
-    document.getElementById("Project_").style.height =
-        document.querySelector("#Project").offsetWidth + "px";
+        'px';
+    document.getElementById('About_').style.height =
+        document.querySelector('.before-goals').offsetWidth + 'px';
+    document.getElementById('Project_').style.height =
+        document.querySelector('#Project').offsetWidth + 'px';
 }
 
 function permission() {
     if (!DeviceOrientationEvent.requestPermission) return;
     DeviceOrientationEvent.requestPermission()
         .then(response => {
-            if (response == "granted") {
-                window.addEventListener("deviceorientation", e => {
+            if (response == 'granted') {
+                window.addEventListener('deviceorientation', e => {
                     x = (rotation ? e.beta : e.gamma) / 6;
                     y = (rotation ? -e.gamma : e.beta) / 6;
                     header.style.transform = `translate3d(${-x}vh, ${-y}vh,0)`;
@@ -155,27 +155,27 @@ function permission() {
         .catch(console.error);
 }
 
-window.addEventListener("resize", () => {
+window.addEventListener('resize', () => {
     checkRotation();
     permission();
 });
 
-//Scroll Effect
+// Scroll Effect
 
 // Scale big header on scroll
 
-const bigHeader = document.querySelector("header");
-const container = document.querySelector(".container");
-const PastActivities = document.querySelector("#Pastevents");
-const charger = document.querySelector(".sponsor-fixed .sponsor-charger");
-const fixedCharger = document.querySelector(".sponsor-charger.fixed");
-const clubTitle = document.getElementById("clubTitle");
-const introImg = document.querySelector(".introImg");
+const bigHeader = document.querySelector('header');
+const container = document.querySelector('.container');
+const PastActivities = document.querySelector('#Pastevents');
+const charger = document.querySelector('.sponsor-fixed .sponsor-charger');
+const fixedCharger = document.querySelector('.sponsor-charger.fixed');
+const clubTitle = document.getElementById('clubTitle');
+const introImg = document.querySelector('.introImg');
 let containerScrollWidth, SponsorBoxForHeight;
 window.onload = () => {
     checkRotation();
 };
-// for scroll don't need original window.innerHeight;
+// For scroll don't need original window.innerHeight;
 const scrollFunction = () => {
     if (window.scrollY < (window.innerHeight * 1.15) / 3)
         bigHeader.style.transform = `scale(${
@@ -184,7 +184,7 @@ const scrollFunction = () => {
     // 透明度轉場
     if (window.scrollY > window.innerHeight * 0.05) {
         if (window.scrollY < (window.innerHeight * 1.15) / 3) {
-            bigHeader.style.pointerEvents = "all";
+            bigHeader.style.pointerEvents = 'all';
             bigHeader.style.opacity =
                 1 -
                 ((window.scrollY - window.innerHeight * 0.05) /
@@ -196,18 +196,18 @@ const scrollFunction = () => {
                 3;
         } else {
             // 轉場結束
-            bigHeader.style.pointerEvents = "none";
+            bigHeader.style.pointerEvents = 'none';
             bigHeader.style.opacity = 0;
             About.style.opacity = 1;
             if (window.scrollY < containerScrollWidth) {
                 container.style.transform =
-                    "translateX(" +
+                    'translateX(' +
                     ((window.innerHeight * 1.15) / 3 - window.scrollY) +
-                    "px)";
-                var projectOffset = document
-                    .getElementById("Project")
+                    'px)';
+                const projectOffset = document
+                    .getElementById('Project')
                     .getBoundingClientRect().left;
-                //0.684
+                // 0.684
                 if (
                     projectOffset < window.innerWidth &&
                     projectOffset > window.innerHeight * -0.684
@@ -218,36 +218,36 @@ const scrollFunction = () => {
                                 (window.innerWidth +
                                     window.innerHeight * 0.684)) *
                             100 +
-                        "%";
+                        '%';
                     console.log(
-                        (1 - projectOffset / window.innerWidth) * 100 + "%"
+                        (1 - projectOffset / window.innerWidth) * 100 + '%'
                     );
                 }
             } else {
                 container.style.transform =
-                    "translate(-" +
+                    'translate(-' +
                     (container.offsetWidth - window.innerWidth) +
-                    "px," +
+                    'px,' +
                     ((window.innerHeight * 1.15) / 3 -
                         window.scrollY +
                         containerScrollWidth -
                         window.innerHeight / 2) +
-                    "px)";
+                    'px)';
             }
             fixedCharger.classList.toggle(
-                "rise",
+                'rise',
                 window.scrollY + window.innerHeight / 5.5 > containerScrollWidth
             );
             if (clubTitle.getBoundingClientRect().top < window.innerHeight) {
                 fixedCharger.style.transform =
-                    "translateY(" +
+                    'translateY(' +
                     (clubTitle.getBoundingClientRect().top -
                         window.innerHeight) +
-                    "px)";
-                fixedCharger.style.transitionDuration = ".1s";
+                    'px)';
+                fixedCharger.style.transitionDuration = '.1s';
             } else {
-                fixedCharger.style.transform = "";
-                fixedCharger.style.transitionDuration = ".4s";
+                fixedCharger.style.transform = '';
+                fixedCharger.style.transitionDuration = '.4s';
             }
         }
     } else {
@@ -256,16 +256,16 @@ const scrollFunction = () => {
     }
 };
 
-var last = window.scrollY;
-window.addEventListener("scroll", scrollFunction);
+const last = window.scrollY;
+window.addEventListener('scroll', scrollFunction);
 scrollFunction();
 
-elements = document.querySelectorAll(".tree i");
+elements = document.querySelectorAll('.tree i');
 elements.forEach(element => {
-    element.addEventListener("click", () => {
-        element.style.top = "100%";
+    element.addEventListener('click', () => {
+        element.style.top = '100%';
         setTimeout(() => {
-            window.open(element.getAttribute("link"), "_blank");
+            window.open(element.getAttribute('link'), '_blank');
         }, 300);
     });
 });

--- a/tool/countdown/index.html
+++ b/tool/countdown/index.html
@@ -2,54 +2,57 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>10-Minute Timer</title>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Aldrich&display=swap');
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>10-Minute Timer</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Aldrich&display=swap');
 
-        body {
-            background-color: black;
-            color: white;
-            font-family: 'Aldrich', sans-serif;
-            text-align: center;
-            font-size: 10rem;
-        }
-        .timer {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: 100%;
-        }
-        .timer div {
-            margin: 0;
-            width: .8em;
-            overflow: hidden;
-        }
-    </style>
+    body {
+      background-color: black;
+      color: white;
+      font-family: 'Aldrich', sans-serif;
+      text-align: center;
+      font-size: 10rem;
+    }
+
+    .timer {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+    }
+
+    .timer div {
+      margin: 0;
+      width: .8em;
+      overflow: hidden;
+    }
+  </style>
 </head>
+
 <body>
-    <div class="timer">
-        <div></div>
-        <div></div>
-        <div>:</div>
-        <div></div>
-        <div></div>
-    </div>
-    <script>
-        const urlParams = new URLSearchParams(window.location.search);
-var countdown = urlParams.get('t') ? parseInt(urlParams.get('t')) : 600;
+  <div class="timer">
+    <div></div>
+    <div></div>
+    <div>:</div>
+    <div></div>
+    <div></div>
+  </div>
+  <script>
+    const urlParams = new URLSearchParams(window.location.search);
+    let countdown = urlParams.get('t') ? parseInt(urlParams.get('t')) : 600;
 
-function startTimer() {
-    var timerDisplay = document.querySelector(".timer");
+    function startTimer() {
+      let timerDisplay = document.querySelector('.timer');
 
-    var timer = setInterval(function() {
-        var minutes = Math.floor(countdown / 60);
-        var seconds = countdown % 60;
+      let timer = setInterval(function () {
+        let minutes = Math.floor(countdown / 60);
+        let seconds = countdown % 60;
 
         // Add leading zeros if needed
-        var minutesStr = minutes < 10 ? "0" + minutes : minutes.toString();
-        var secondsStr = seconds < 10 ? "0" + seconds : seconds.toString();
+        let minutesStr = minutes < 10 ? '0' + minutes : minutes.toString();
+        let secondsStr = seconds < 10 ? '0' + seconds : seconds.toString();
 
         // Update the individual div elements
         timerDisplay.children[0].textContent = minutesStr[0];
@@ -58,14 +61,15 @@ function startTimer() {
         timerDisplay.children[4].textContent = secondsStr[1];
 
         if (countdown === 0) {
-            clearInterval(timer);
+          clearInterval(timer);
         } else {
-            countdown--;
+          countdown--;
         }
-    }, 1000);
-}
+      }, 1000);
+    }
 
-startTimer();
-    </script>
+    startTimer();
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
* **移除專案中使用之中華人民共和國之用語**
* 將使用的標點符號改為中華民國教育部公布之[《重訂標點符號手冊》修訂版](https://language.moe.gov.tw/001/upload/files/site_content/m0001/hau/haushou.htm)
* 重新排版以符合[《中文文案排版指北》](https://github.com/sparanoid/chinese-copywriting-guidelines)
* 將部分未明確指定之字型改為 [Noto Sans Traditional Chinese](https://fonts.google.com/noto/specimen/Noto+Sans+TC)
* 將 JavaScript 使用的引號統一為 `'`
* 將 JavaScript 使用的變數宣告由 `var` 改成更安全的 `let`
* 將 HTML 使用的引號統一為 `"`
* 改錯字